### PR TITLE
feat: create seed script for tables

### DIFF
--- a/packages/celestia-database/README.md
+++ b/packages/celestia-database/README.md
@@ -22,3 +22,13 @@ Create migrations with:
 
 Execute migrations with:
 `npx db-migrate up` & `npx db-migrate down`
+
+# Spin up local database
+create the local database:
+`createdb celestia`
+
+To run migrations:
+`npx db-migrate up`
+
+Seed the database:
+`yarn seed-db`

--- a/packages/celestia-database/database.json
+++ b/packages/celestia-database/database.json
@@ -3,6 +3,7 @@
     "driver": "pg",
     "host": "localhost",
     "database": "celestia",
-    "user": "postgres"
+    "user": "postgres",
+    "password": "password"
   }
 }

--- a/packages/celestia-database/migrations/20230907102448-create-table-locations.js
+++ b/packages/celestia-database/migrations/20230907102448-create-table-locations.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230907102448-create-table-locations-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230907102448-create-table-locations-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/celestia-database/migrations/sqls/20230907102448-create-table-locations-down.sql
+++ b/packages/celestia-database/migrations/sqls/20230907102448-create-table-locations-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE celestia_public.location;

--- a/packages/celestia-database/migrations/sqls/20230907102448-create-table-locations-up.sql
+++ b/packages/celestia-database/migrations/sqls/20230907102448-create-table-locations-up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE celestia_public.location (
+  id serial PRIMARY KEY,
+  system_name text NOT NULL,
+  system_id int NOT NULL,
+  region_name TEXT NOT NULL,
+  region_id int NOT NULL
+);
+
+COMMENT ON TABLE celestia_public.location IS 'A table each location in Eve Online.';
+COMMENT ON COLUMN celestia_public.location.system_name IS 'The name for a single solar system.';
+COMMENT ON COLUMN celestia_public.location.system_id IS 'The ID for a single solar system.';
+COMMENT ON COLUMN celestia_public.location.region_name IS 'The region name that this solar system is in.';
+COMMENT ON COLUMN celestia_public.location.region_id IS 'The ID for the region that this solar system is in.';

--- a/packages/celestia-database/package.json
+++ b/packages/celestia-database/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": "https://github.com/Codykilpatrick/Celestia.git",
   "scripts": {
-    "db:connect": "npx postgraphile -c postgres:///celestia --schema celestia_public"
+    "db:connect": "npx postgraphile -c postgres:///celestia --schema celestia_public",
+    "seed-db": "chmod +x seed_db.sh && ./seed_db.sh"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/celestia-database/seed_data/item_ids.csv
+++ b/packages/celestia-database/seed_data/item_ids.csv
@@ -1,4 +1,4 @@
-id,name
+type_id,name
 0,#System
 2,Corporation
 3,Region

--- a/packages/celestia-database/seed_data/location_ids.csv
+++ b/packages/celestia-database/seed_data/location_ids.csv
@@ -1,0 +1,6 @@
+region_id,system_id,system_name,region_name
+10000043,30002187,amarr,domain
+10000002,30000142,jita,the forge
+10000030,30002510,rens,heimatar
+10000032,30002659,dodixie,sinq laison
+10000042,30002053,hek,metropolis

--- a/packages/celestia-database/seed_db.sh
+++ b/packages/celestia-database/seed_db.sh
@@ -12,6 +12,7 @@ ITEM_TABLE="./seed_data/item_ids.csv"
 
 # Run the PostgreSQL command to seed the database
 psql "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" <<EOF
+DELETE FROM celestia_public.item;
 \COPY celestia_public.item (type_id, item_name) FROM '${ITEM_TABLE}' DELIMITER ',' CSV HEADER;
 EOF
 
@@ -20,5 +21,6 @@ LOCATION_TABLE="./seed_data/location_ids.csv"
 
 # Run the PostgreSQL command to seed the database with the second CSV file
 psql "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" <<EOF
+DELETE FROM celestia_public.location;
 \COPY celestia_public.location (region_id, system_id, system_name, region_name) FROM '${LOCATION_TABLE}' DELIMITER ',' CSV HEADER;
 EOF

--- a/packages/celestia-database/seed_db.sh
+++ b/packages/celestia-database/seed_db.sh
@@ -8,9 +8,17 @@ DB_PORT="5432"
 DB_NAME="celestia"
 
 # Define the path to your CSV file
-CSV_FILE="./seed_data/item_ids.csv"
+ITEM_TABLE="./seed_data/item_ids.csv"
 
 # Run the PostgreSQL command to seed the database
 psql "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" <<EOF
-\COPY celestia_public.item (type_id, item_name) FROM '${CSV_FILE}' DELIMITER ',' CSV HEADER;
+\COPY celestia_public.item (type_id, item_name) FROM '${ITEM_TABLE}' DELIMITER ',' CSV HEADER;
+EOF
+
+# Define the relative path to your second CSV file
+LOCATION_TABLE="./seed_data/location_ids.csv"
+
+# Run the PostgreSQL command to seed the database with the second CSV file
+psql "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" <<EOF
+\COPY celestia_public.location (region_id, system_id, system_name, region_name) FROM '${LOCATION_TABLE}' DELIMITER ',' CSV HEADER;
 EOF

--- a/packages/celestia-database/seed_db.sh
+++ b/packages/celestia-database/seed_db.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Define your PostgreSQL connection parameters
+DB_USER="postgres"
+DB_PASSWORD="password"
+DB_HOST="localhost"
+DB_PORT="5432"
+DB_NAME="celestia"
+
+# Define the path to your CSV file
+CSV_FILE="./seed_data/item_ids.csv"
+
+# Run the PostgreSQL command to seed the database
+psql "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}" <<EOF
+\COPY celestia_public.item (type_id, item_name) FROM '${CSV_FILE}' DELIMITER ',' CSV HEADER;
+EOF


### PR DESCRIPTION
First I created the last migration for the location table so right now every table in the schema on miro has a table.

Also I wrote a bash script that will seed the items table and the locations table. Right now for locations I only did 5 solar systems. These are the top trading hubs in the game and should suffice for now and we can add the other systems later.

Also this is a positive for starting out with local DB's working on this I probably did about 200k inserts and the same amount of deletes.

**Test plan (required)**
**MUST HAVE POSTGRES INSTALLED**
create the local database:
`createdb celestia`

To run migrations:
`npx db-migrate up`

Seed the database:
`yarn seed-db`

You should see something like this in the terminal if everything worked:
```
DELETE 46228
COPY 46228
DELETE 5
COPY 5
```

**Closing issues**
Closes #12 
