### PR TITLE
feat: update market history

### DIFF
--- a/packages/celestia-database/migrations/20230915114459-create-table-pull-history-sync.js
+++ b/packages/celestia-database/migrations/20230915114459-create-table-pull-history-sync.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230915114459-create-table-pull-history-sync-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230915114459-create-table-pull-history-sync-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/celestia-database/migrations/sqls/20230915114459-create-table-pull-history-sync-down.sql
+++ b/packages/celestia-database/migrations/sqls/20230915114459-create-table-pull-history-sync-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE celestia_public.market_history_sync;

--- a/packages/celestia-database/migrations/sqls/20230915114459-create-table-pull-history-sync-up.sql
+++ b/packages/celestia-database/migrations/sqls/20230915114459-create-table-pull-history-sync-up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE celestia_public.market_history_sync (
+  id serial PRIMARY KEY,
+  date text NOT NULL,
+  highest NUMERIC(14, 2) NOT NULL,
+  lowest NUMERIC(14, 2) NOT NULL,
+  average NUMERIC(14, 2) NOT NULL,
+  order_count int,
+  region_id int,
+  type_id int,
+  volume bigint
+);
+
+COMMENT ON TABLE celestia_public.market_history_sync IS 'A list of historical market statistics for a given region.';
+COMMENT ON COLUMN celestia_public.market_history_sync.date IS 'The date of this historical statistic entry';
+COMMENT ON COLUMN celestia_public.market_history_sync.highest IS 'The highest an item sold for on this date in this region.';
+COMMENT ON COLUMN celestia_public.market_history_sync.lowest IS 'The lowest an item sold for on this date in this region.';
+COMMENT ON COLUMN celestia_public.market_history_sync.average IS 'The average price an item sold for on this date in this region.';
+COMMENT ON COLUMN celestia_public.market_history_sync.order_count IS 'The ammount of individual orders for this item in a specific region.';
+COMMENT ON COLUMN celestia_public.market_history_sync.volume IS 'The ammount of individual items across all orders for this item in a specific region.';
+COMMENT ON COLUMN celestia_public.market_history_sync.region_id IS 'The region id that is for this data entry.';
+COMMENT ON COLUMN celestia_public.market_history_sync.type_id IS 'The type id for the item that is for this data entry.';
+
+CREATE INDEX idx_region_type_date ON celestia_public.market_history_sync (region_id, type_id, date);

--- a/packages/celestia-models/pipeline/sync_market_history.py
+++ b/packages/celestia-models/pipeline/sync_market_history.py
@@ -39,6 +39,10 @@ def main():
         print("Processing:", region_id)
         sync_table(connection, region_id)
 
+    cursor = connection.cursor()
+    query = "DELETE FROM celestia_public.market_history_sync;"
+    cursor.execute(query)
+    connection.commit()
     connection.close()
 
 

--- a/packages/celestia-models/pipeline/sync_market_history.py
+++ b/packages/celestia-models/pipeline/sync_market_history.py
@@ -14,15 +14,12 @@ def sync_table(connection, region_id):
     dates = pd.DataFrame(dates_in_current, columns=['id', 'date', 'highest', 'lowest', 'average', 'order_count', 'region_id', 'type_id', 'volume'])
     unique_dates = dates['date'].unique()
     new_data_trimmed = new_data[~new_data['date'].isin(unique_dates)]
-    
-    # Append new_data_trimmed to the PostgreSQL table
     insert_query = """
         INSERT INTO celestia_public.market_history_pull
         (date, highest, lowest, average, order_count, region_id, type_id, volume)
         VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
     """
     values = [tuple(row) for row in new_data_trimmed[['date', 'highest', 'lowest', 'average', 'order_count', 'region_id', 'type_id', 'volume']].values]
-    
     try:
         cursor.executemany(insert_query, values)
         connection.commit()
@@ -32,9 +29,8 @@ def sync_table(connection, region_id):
         print(f"Error inserting data: {e}")
 
 
-
 def main():
-    db_params = { 'host': 'localhost', 'database': 'celestia', 'user': 'postgres', 'password': 'password', }
+    db_params = {'host': 'localhost', 'database': 'celestia', 'user': 'postgres', 'password': 'password', }
 
     connection = psycopg2.connect(**db_params)
     region_ids = [10000043, 10000002, 10000030, 10000032, 10000042]

--- a/packages/celestia-models/pipeline/sync_market_history.py
+++ b/packages/celestia-models/pipeline/sync_market_history.py
@@ -1,0 +1,28 @@
+import psycopg2
+import pandas as pd
+
+
+def sync_table(connection, region_id):
+    cursor = connection.cursor()
+    query = f"SELECT * FROM celestia_public.market_history_sync WHERE region_id = {region_id};"
+    cursor.execute(query)
+    new_results = cursor.fetchall()
+    data = pd.DataFrame(new_results, columns=['id', 'date', 'highest', 'lowest', 'average', 'order_count', 'region_id', 'type_id', 'volume'])
+    print(data)
+
+
+def main():
+    db_params = { 'host': 'localhost', 'database': 'celestia', 'user': 'postgres', 'password': 'password', }
+
+    connection = psycopg2.connect(**db_params)
+    region_ids = [10000043, 10000002, 10000030, 10000032, 10000042]
+    # Get the list of active item_ids
+    for region_id in region_ids:
+        print("Processing:", region_id)
+        sync_table(connection, region_id)
+
+    connection.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/celestia-models/pipeline/sync_market_history.py
+++ b/packages/celestia-models/pipeline/sync_market_history.py
@@ -7,8 +7,30 @@ def sync_table(connection, region_id):
     query = f"SELECT * FROM celestia_public.market_history_sync WHERE region_id = {region_id};"
     cursor.execute(query)
     new_results = cursor.fetchall()
-    data = pd.DataFrame(new_results, columns=['id', 'date', 'highest', 'lowest', 'average', 'order_count', 'region_id', 'type_id', 'volume'])
-    print(data)
+    new_data = pd.DataFrame(new_results, columns=['id', 'date', 'highest', 'lowest', 'average', 'order_count', 'region_id', 'type_id', 'volume'])
+    query_dates = f"SELECT * FROM celestia_public.market_history_pull WHERE region_id = {region_id};"
+    cursor.execute(query_dates)
+    dates_in_current = cursor.fetchall()
+    dates = pd.DataFrame(dates_in_current, columns=['id', 'date', 'highest', 'lowest', 'average', 'order_count', 'region_id', 'type_id', 'volume'])
+    unique_dates = dates['date'].unique()
+    new_data_trimmed = new_data[~new_data['date'].isin(unique_dates)]
+    
+    # Append new_data_trimmed to the PostgreSQL table
+    insert_query = """
+        INSERT INTO celestia_public.market_history_pull
+        (date, highest, lowest, average, order_count, region_id, type_id, volume)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
+    """
+    values = [tuple(row) for row in new_data_trimmed[['date', 'highest', 'lowest', 'average', 'order_count', 'region_id', 'type_id', 'volume']].values]
+    
+    try:
+        cursor.executemany(insert_query, values)
+        connection.commit()
+        print(f"{len(new_data_trimmed)} rows appended to market_history_pull for region_id {region_id}")
+    except psycopg2.Error as e:
+        connection.rollback()
+        print(f"Error inserting data: {e}")
+
 
 
 def main():

--- a/packages/celestia-models/pipeline/update_historic_table.py
+++ b/packages/celestia-models/pipeline/update_historic_table.py
@@ -1,0 +1,9 @@
+import subprocess
+
+# Run update_market_history.py
+update_process = subprocess.Popen(['python', 'update_market_history.py'])
+update_process.wait()  # Wait for update_market_history.py to complete
+
+# Run sync_market_history.py
+sync_process = subprocess.Popen(['python', 'sync_market_history.py'])
+sync_process.wait()  # Wait for sync_market_history.py to complete

--- a/packages/celestia-models/pipeline/update_market_history.py
+++ b/packages/celestia-models/pipeline/update_market_history.py
@@ -27,7 +27,6 @@ async def fetch_history(session, type_id, region_id):
         return type_id, None
 
 
-
 async def fetch_data_for_region(region_id, conn):
     url = f"https://esi.evetech.net/latest/markets/{region_id}/types/?datasource=tranquility"
 

--- a/packages/celestia-models/pipeline/update_market_history.py
+++ b/packages/celestia-models/pipeline/update_market_history.py
@@ -1,0 +1,118 @@
+import asyncio
+import aiohttp
+import asyncpg
+import time
+
+
+async def fetch_history(session, type_id, region_id):
+    history_url = f"https://esi.evetech.net/latest/markets/{region_id}/history/?datasource=tranquility&type_id={type_id}"
+    try:
+        async with session.get(history_url) as response:
+            if response.status == 500:
+                print("Received a 500 response. Waiting and retrying...")
+                await asyncio.sleep(60)  
+                return await fetch_history(session, type_id, region_id)
+            if response.status == 200:
+                data = await response.json()
+                return type_id, data
+            else:
+                error_message = f"Request failed with status code {response.status} for type_id {type_id} in {region_id}"
+                print(error_message)
+                log_failed_request(error_message)  # Log the error to a file
+                return type_id, None
+    except Exception as e:
+        error_message = f"An error occurred for type_id {type_id}: {str(e)} {region_id}"
+        print(error_message)
+        log_failed_request(error_message)  # Log the error to a file
+        return type_id, None
+
+
+
+async def fetch_data_for_region(region_id, conn):
+    url = f"https://esi.evetech.net/latest/markets/{region_id}/types/?datasource=tranquility"
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                if response.status == 200:
+                    region_current_types = await response.json()
+                    print(f"the current types for {region_id} are {region_current_types}")
+                else:
+                    error_message = f"An error occured getting types from {region_id} with code {response.status}"
+                    log_failed_request(error_message)  # Log the error to a file
+                    print(f"Request failed with status code {response.status} for region_id {region_id}")
+                    return
+    except Exception as e:
+        error_message = f"An exception occured getting types for region: {region_id} with exception {str(e)}"
+        log_failed_request(error_message)  # Log the error to a file
+        print(f"An error occurred for region_id {region_id}: {str(e)}")
+        return
+
+    tasks = []
+    total_items = len(region_current_types)
+    processed_items = 0
+
+    async with aiohttp.ClientSession() as session:  # Create a new session
+        for type_id in region_current_types:
+            task = asyncio.ensure_future(fetch_history(session, type_id, region_id))
+            tasks.append(task)
+
+        for future in asyncio.as_completed(tasks):
+            type_id, data = await future
+            print("TYPE_ID", type_id)
+            processed_items += 1
+            progress = (processed_items / total_items) * 100
+            print(f"Fetched data for type_id {type_id}")
+            print(f"{progress:.2f}% done")
+
+            if data is not None:
+                for row in data:
+                    await conn.execute(
+                        "INSERT INTO celestia_public.market_history_sync (type_id, date, average, highest, lowest, order_count, volume, region_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                        type_id,
+                        row['date'],
+                        row['average'],
+                        row['highest'],
+                        row['lowest'],
+                        row['order_count'],
+                        row['volume'],
+                        region_id
+                    )
+
+
+def log_failed_request(error_message):
+    with open("failed_requests.txt", "a") as file:
+        file.write(error_message + "\n")
+
+
+async def main():
+    start_time = time.time()
+    database_url = "postgresql://postgres:password@localhost/celestia"
+    conn = await asyncpg.connect(database_url)
+    region_ids = [10000043, 10000002, 10000030, 10000032, 10000042]
+
+    while True:  # Run indefinitely
+        all_regions_processed = True
+
+        for region_id in region_ids:
+            try:
+                print("Fetching data for region_id", region_id)
+                await fetch_data_for_region(region_id, conn)
+            except aiohttp.ClientResponseError as e:
+                if e.status == 500:
+                    print("Received a 500 response. Waiting and retrying...")
+                    await asyncio.sleep(60)
+                    raise
+
+            if not all_regions_processed:
+                all_regions_processed = False
+
+        if all_regions_processed:
+            break
+
+    end_time = time.time()  # Record the end time
+    elapsed_time = end_time - start_time  # Calculate the elapsed time
+    print(f"Total time taken: {elapsed_time} seconds")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/celestia-models/pipeline/update_market_history.py
+++ b/packages/celestia-models/pipeline/update_market_history.py
@@ -10,7 +10,7 @@ async def fetch_history(session, type_id, region_id):
         async with session.get(history_url) as response:
             if response.status == 500:
                 print("Received a 500 response. Waiting and retrying...")
-                await asyncio.sleep(60)  
+                await asyncio.sleep(60)
                 return await fetch_history(session, type_id, region_id)
             if response.status == 200:
                 data = await response.json()
@@ -91,7 +91,7 @@ async def main():
     conn = await asyncpg.connect(database_url)
     region_ids = [10000043, 10000002, 10000030, 10000032, 10000042]
 
-    while True:  # Run indefinitely
+    while True:
         all_regions_processed = True
 
         for region_id in region_ids:

--- a/packages/celestia-models/pipeline/update_market_history.py
+++ b/packages/celestia-models/pipeline/update_market_history.py
@@ -100,7 +100,8 @@ async def main():
                 await fetch_data_for_region(region_id, conn)
             except aiohttp.ClientResponseError as e:
                 if e.status == 500:
-                    print("Received a 500 response. Waiting and retrying...")
+                    error_message = f"Received a 500 response. Waiting and retrying... for region {region_id}"
+                    log_failed_request(error_message)
                     await asyncio.sleep(60)
                     raise
 

--- a/packages/celestia-models/pipeline/update_market_history.py
+++ b/packages/celestia-models/pipeline/update_market_history.py
@@ -19,6 +19,7 @@ async def fetch_history(session, type_id, region_id):
                 error_message = f"Request failed with status code {response.status} for type_id {type_id} in {region_id}"
                 print(error_message)
                 log_failed_request(error_message)  # Log the error to a file
+                await asyncio.sleep(5)
                 return type_id, None
     except Exception as e:
         error_message = f"An error occurred for type_id {type_id}: {str(e)} {region_id}"

--- a/packages/celestia-models/pipeline/update_market_history.py
+++ b/packages/celestia-models/pipeline/update_market_history.py
@@ -102,6 +102,7 @@ async def main():
                 if e.status == 500:
                     error_message = f"Received a 500 response. Waiting and retrying... for region {region_id}"
                     log_failed_request(error_message)
+                    await conn.execute("DELETE from celestia_public.market_history_sync WHERE region_id = $1", region_id)
                     await asyncio.sleep(60)
                     raise
 


### PR DESCRIPTION
This PR adds the python scripts that will pull down market history, check the differences between the new pull and the production DB and append the new data. Then it will clear out the synced data. I image that this will run in a gh_action on a cron schedule so it hits every day at whatever time.

**Test plan (required)**
Setup all the postgres/db migration stuff
cd celestia/models
poetry install
poetry shell
cd pipeline

run:
python update_historic_table.py

And you should see it pulling down the new data and eventually:
```
Total time taken: 188.32438015937805 seconds
Processing: 10000043
0 rows appended to market_history_pull for region_id 10000043
Processing: 10000002
0 rows appended to market_history_pull for region_id 10000002
Processing: 10000030
0 rows appended to market_history_pull for region_id 10000030
Processing: 10000032
0 rows appended to market_history_pull for region_id 10000032
Processing: 10000042
0 rows appended to market_history_pull for region_id 10000042
```

Closes #14 