### PR TITLE
feat: create filter by region

### DIFF
--- a/packages/celestia-app/src/apollo/graphql-queries.ts
+++ b/packages/celestia-app/src/apollo/graphql-queries.ts
@@ -20,8 +20,8 @@ export const ALL_PREDICTIONS_QUERY = gql`
 `;
 
 export const ITEM_HISTORY_QUERY = gql`
-  query itemHistoryById($typeId: Int!) {
-    allMarketHistoryPulls(condition: { regionId: 10000043, typeId: $typeId }, orderBy: DATE_ASC) {
+  query itemHistoryById($typeId: Int!, $regionId: Int!) {
+    allMarketHistoryPulls(condition: { regionId: $regionId, typeId: $typeId }, orderBy: DATE_ASC) {
       edges {
         node {
           typeId

--- a/packages/celestia-app/src/apollo/graphql-queries.ts
+++ b/packages/celestia-app/src/apollo/graphql-queries.ts
@@ -1,8 +1,8 @@
 const { gql } = require('@apollo/client');
 
 export const ALL_PREDICTIONS_QUERY = gql`
-  query allPredictions {
-    allModelPredictAverageIncreases(condition: { regionId: 10000043, increase: false }) {
+  query allPredictionsById($regionId: Int!) {
+    allModelPredictAverageIncreases(condition: { regionId: $regionId, increase: false }) {
       totalCount
       edges {
         node {

--- a/packages/celestia-app/src/components/graph.tsx
+++ b/packages/celestia-app/src/components/graph.tsx
@@ -17,16 +17,17 @@ interface PriceItem {
 interface GraphProps {
   currentItem: number | undefined;
   currentItemName: string | undefined;
+  currentRegionId: number | undefined;
 }
 
-const Graph = ({ currentItem, currentItemName }: GraphProps) => {
+const Graph = ({ currentItem, currentItemName, currentRegionId }: GraphProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const {
     data: prices,
     error,
     refetch,
   } = useQuery(ITEM_HISTORY_QUERY, {
-    variables: { typeId: currentItem },
+    variables: { typeId: currentItem, regionId: currentRegionId },
   });
 
   useEffect(() => {

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -116,7 +116,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   return (
     <div className="h-full mx-12">
       <div className="bg-violet-3 mt-16 text-mauve-11 rounded-lg overflow-hidden">
-        <Graph currentItem={currentItem} currentItemName={currentItemName} />
+        <Graph currentItem={currentItem} currentItemName={currentItemName} currentRegionId={currentRegionId} />
       </div>
       <div className="bg-violet-3 mt-16 rounded-lg">
         <div className="flex justify-center pt-4">

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -47,6 +47,9 @@ const Hero = ({ predictions, itemNames, locationNames }: HeroProps) => {
   const itemMap: Record<string, string> = {};
   const locationMap: Record<string, string> = {};
   const [currentItem, setCurrentItem] = useState<number | undefined>();
+  const [selectedOption, setSelectedOption] = useState('10000043');
+  console.log(selectedOption);
+  
   const [currentItemName, setCurrentItemName] = useState<string | undefined>();
 
   const handleItemClick = (itemId: number, itemName: string) => {
@@ -78,8 +81,25 @@ const Hero = ({ predictions, itemNames, locationNames }: HeroProps) => {
         <Graph currentItem={currentItem} currentItemName={currentItemName} />
       </div>
       <div className="bg-violet-3 mt-16 rounded-lg">
-        <div className="flex justify-center ">
-          <div className="mx-4 text-mauve-12">Filter by Region</div>
+        <div className="flex justify-center pt-4">
+          <div className="mx-4">
+            <label htmlFor="regionSelect" className="text-mauve-12">
+              Filter by Region:
+            </label>
+            <select
+              id="regionSelect"
+              value={selectedOption}
+              onChange={(e) => setSelectedOption(e.target.value)}
+              className='bg-violet-7 ml-2 rounded-lg'
+            >
+              <option value="">Select a Region</option>
+              <option value="10000043">Domain</option>
+              <option value="10000002">The Forge</option>
+              <option value="10000030">Heimatar</option>
+              <option value="10000032">Sinq Laison</option>
+              <option value="10000042">Metropolis</option>
+            </select>
+          </div>
           <div className="mx-4 text-mauve-12">Search Item</div>
         </div>
         <div className="flex justify-center">

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -59,7 +59,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     error,
     refetch,
   } = useQuery(ALL_PREDICTIONS_QUERY, {
-    variables: { typeId: currentItem },
+    variables: { regionId: currentRegionId },
   });
 
   useEffect(() => {
@@ -100,12 +100,11 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     itemMap[node.id] = node.itemName;
   });
 
-  
-  const newPredictions = predictions?.allModelPredictAverageIncreases?.edges || []
-  const firstPrediction = newPredictions[0]?.node
+  const newPredictions = predictions?.allModelPredictAverageIncreases?.edges || [];
+  const firstPrediction = newPredictions[0]?.node;
 
   if (!firstPrediction) {
-    return <div>No predictions available for this region.</div>
+    return <div>No predictions available for this region.</div>;
   }
 
   const predictionsWithItemNames = newPredictions.map(({ node }) => ({

--- a/packages/celestia-app/src/pages/index.tsx
+++ b/packages/celestia-app/src/pages/index.tsx
@@ -4,12 +4,6 @@ import Header from '@/components/header';
 import Hero from '@/components/hero';
 import Footer from '@/components/footer';
 import client from '@/apollo/apollo-client';
-import {
-  ALL_PREDICTIONS_QUERY,
-  ITEM_HISTORY_QUERY,
-  ALL_ITEMS_QUERY,
-  ALL_LOCATIONS_QUERY,
-} from '@/apollo/graphql-queries';
 
 interface PredictionNode {
   id: string;
@@ -56,38 +50,17 @@ interface HomeProps {
   }[];
 }
 
-const Home = ({ predictions, itemNames, locationNames }: HomeProps) => {
+const Home = ({ itemNames, locationNames }: HomeProps) => {
   return (
     <div className="w-full">
       <Header />
-      <Hero predictions={predictions} itemNames={itemNames} locationNames={locationNames} />
+      <Hero itemNames={itemNames} locationNames={locationNames} />
       <Footer />
     </div>
   );
 };
 
 export async function getStaticProps() {
-  const { data: predictions } = await client.query({
-    query: gql`
-      query allPredictions {
-        allModelPredictAverageIncreases(condition: { regionId: 10000043, increase: false }) {
-          totalCount
-          edges {
-            node {
-              id
-              regionId
-              increase
-              horizon
-              confidence
-              datePredicted
-              typeId
-            }
-          }
-        }
-      }
-    `,
-  });
-
   const { data: prices } = await client.query({
     query: gql`
       query itemHistoryById {
@@ -140,7 +113,6 @@ export async function getStaticProps() {
 
   return {
     props: {
-      predictions: [predictions],
       prices: [prices],
       itemNames: [itemNames],
       locationNames: [locationNames],


### PR DESCRIPTION
Allows users to filter through a list of regions to see  the market predictions for that region.

Closes #41 