### PR TITLE
feat: update predictions table

### DIFF
--- a/packages/celestia-app/src/apollo/graphql-queries.ts
+++ b/packages/celestia-app/src/apollo/graphql-queries.ts
@@ -2,7 +2,7 @@ const { gql } = require('@apollo/client');
 
 export const ALL_PREDICTIONS_QUERY = gql`
   query allPredictionsById($regionId: Int!) {
-    allModelPredictAverageIncreases(condition: { regionId: $regionId, increase: false }) {
+    allModelPredictAverageIncreases(condition: { regionId: $regionId }) {
       totalCount
       edges {
         node {

--- a/packages/celestia-app/src/components/footer.tsx
+++ b/packages/celestia-app/src/components/footer.tsx
@@ -1,5 +1,5 @@
 const Footer = () => {
-  return <div className="bg-violet-3 h-16 m-12 rounded-lg text-mauve-11">Footer</div>;
+  return <div className="bg-violet-3 h-16 mx-12 mt-12 rounded-lg text-mauve-11">Footer</div>;
 };
 
 export default Footer;

--- a/packages/celestia-app/src/components/graph.tsx
+++ b/packages/celestia-app/src/components/graph.tsx
@@ -4,6 +4,7 @@ const { Chart, registerables } = require('chart.js');
 Chart.register(...registerables);
 import { ITEM_HISTORY_QUERY } from '@/apollo/graphql-queries';
 const { useQuery } = require('@apollo/client');
+import { violetDark, mauveDark } from '@radix-ui/colors';
 
 interface PriceItem {
   node: {
@@ -108,13 +109,27 @@ const Graph = ({ currentItem, currentItemName, currentRegionId }: GraphProps) =>
         title: {
           display: true,
           text: 'Date',
+          color: mauveDark.mauve11
         },
+        grid: {
+          color: mauveDark.mauve9
+        },
+        ticks: {
+          color: mauveDark.mauve11
+        }
       },
       y: {
         title: {
           display: true,
           text: 'Average Price',
+          color: mauveDark.mauve11
         },
+        grid: {
+          color: mauveDark.mauve9
+        },
+        ticks: {
+          color: mauveDark.mauve11
+        }
       },
     },
     plugins: {
@@ -124,6 +139,7 @@ const Graph = ({ currentItem, currentItemName, currentRegionId }: GraphProps) =>
         font: {
           size: 16,
         },
+        color: mauveDark.mauve11
       },
     },
     maintainAspectRatio: false,

--- a/packages/celestia-app/src/components/graph.tsx
+++ b/packages/celestia-app/src/components/graph.tsx
@@ -61,7 +61,11 @@ const Graph = ({ currentItem, currentItemName, currentRegionId }: GraphProps) =>
   const firstPriceItem = priceHistory[0]?.node;
 
   if (!firstPriceItem) {
-    return <div>No price data available for this item.</div>;
+    return (
+      <div className="h-96 p-2 flex justify-center">
+        <div className="flex flex-col justify-center">No price data available for this item.</div>
+      </div>
+    );
   }
 
   const last30PriceHistory = priceHistory.slice(-30);

--- a/packages/celestia-app/src/components/graph.tsx
+++ b/packages/celestia-app/src/components/graph.tsx
@@ -4,7 +4,7 @@ const { Chart, registerables } = require('chart.js');
 Chart.register(...registerables);
 import { ITEM_HISTORY_QUERY } from '@/apollo/graphql-queries';
 const { useQuery } = require('@apollo/client');
-import { violetDark, mauveDark } from '@radix-ui/colors';
+import { mauveDark } from '@radix-ui/colors';
 
 interface PriceItem {
   node: {

--- a/packages/celestia-app/src/components/graph.tsx
+++ b/packages/celestia-app/src/components/graph.tsx
@@ -109,27 +109,27 @@ const Graph = ({ currentItem, currentItemName, currentRegionId }: GraphProps) =>
         title: {
           display: true,
           text: 'Date',
-          color: mauveDark.mauve11
+          color: mauveDark.mauve11,
         },
         grid: {
-          color: mauveDark.mauve9
+          color: mauveDark.mauve9,
         },
         ticks: {
-          color: mauveDark.mauve11
-        }
+          color: mauveDark.mauve11,
+        },
       },
       y: {
         title: {
           display: true,
           text: 'Average Price',
-          color: mauveDark.mauve11
+          color: mauveDark.mauve11,
         },
         grid: {
-          color: mauveDark.mauve9
+          color: mauveDark.mauve9,
         },
         ticks: {
-          color: mauveDark.mauve11
-        }
+          color: mauveDark.mauve11,
+        },
       },
     },
     plugins: {
@@ -139,7 +139,7 @@ const Graph = ({ currentItem, currentItemName, currentRegionId }: GraphProps) =>
         font: {
           size: 16,
         },
-        color: mauveDark.mauve11
+        color: mauveDark.mauve11,
       },
     },
     maintainAspectRatio: false,

--- a/packages/celestia-app/src/components/header.tsx
+++ b/packages/celestia-app/src/components/header.tsx
@@ -1,7 +1,7 @@
 const Header = () => {
   return (
     <>
-      <div className="bg-violet-3 h-16 mx-12 rounded-b-lg flex-col flex justify-center">
+      <div className="bg-violet-4 h-16 mx-12 rounded-b-lg flex-col flex justify-center">
         <ul className="flex justify-between mx-4">
           <li className="text-mauve-12 px-2">Home</li>
           <li className="text-mauve-12 px-2">Documentation</li>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -128,7 +128,11 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   const firstPrediction = newPredictions[0]?.node;
 
   if (!firstPrediction) {
-    return <div>No predictions available for this region.</div>;
+    return (
+      <div className="h-96 p-2 flex justify-center">
+        <div className="flex flex-col justify-center">No predictions available for this region.</div>
+      </div>
+    );
   }
 
   const predictionsWithItemNames = newPredictions.map(({ node }: { node: Prediction }) => ({

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -153,6 +153,12 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     }
   });
 
+  const changeRegion = (e) =>{
+    setSortBy('')
+    setSortOrder('asc')
+    setCurrentRegionId(parseInt(e.target.value))
+  }
+
   const handleSearch = (searchQuery: string) => {
     const filtered = predictionsWithItemNames.filter((prediction: Prediction) =>
       prediction.itemName.toLowerCase().includes(searchQuery.toLowerCase()),
@@ -174,7 +180,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             <select
               id="regionSelect"
               value={currentRegionId}
-              onChange={(e) => setCurrentRegionId(parseInt(e.target.value))}
+              onChange={(e) => changeRegion(e)}
               className="bg-violet-7 ml-2 rounded-lg"
             >
               <option value={10000043}>Domain</option>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -137,6 +137,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     locationName: locationMap[node.regionId],
   }));
 
+  const totalPages = Math.floor(predictionsWithItemNames.length / itemsPerPage)
 
   let sortedPredictions = [...predictionsWithItemNames].sort((a, b) => {
     if (sortBy === 'locationName') {
@@ -213,6 +214,9 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
           <button className='px-2' onClick={() => setCurrentPage(currentPage - 1)}>
             Previous
           </button>
+          <div>
+            Page: {currentPage} of {totalPages}
+          </div>
           <button className='px-2' onClick={() => setCurrentPage(currentPage + 1)}>
             Next
           </button>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -154,7 +154,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   });
 
   const handleSearch = (searchQuery: string) => {
-    const filtered = predictionsWithItemNames.filter((prediction) =>
+    const filtered = predictionsWithItemNames.filter((prediction: Prediction) =>
       prediction.itemName.toLowerCase().includes(searchQuery.toLowerCase()),
     );
     setFilteredPredictions(filtered);
@@ -185,9 +185,12 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             </select>
           </div>
           <div className="mx-4 text-mauve-12">
-            Search Item:
+            <label htmlFor="searchItem">
+              Search Item:
+            </label>
             <input
               type="text"
+              id="searchItem"
               value={searchTerm}
               onChange={(e) => {
                 setSearchTerm(e.target.value);

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -248,16 +248,16 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             <tbody>
               {searchTerm
                 ? filteredPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className="mx-2">
-                      <td className="border px-4 py-2">{prediction.locationName}</td>
-                      <td className="border px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
-                      <td className="border px-4 py-2">{prediction.horizon}</td>
-                      <td className="border px-4 py-2">{prediction.confidence}</td>
-                      <td className="border px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border px-4 py-2 sm:text-center lg:text-start">
+                    <tr key={prediction.id} className="mx-2 text-mauve-11">
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.locationName}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.horizon}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.confidence}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.datePredicted}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start">
                         {' '}
                         <button
-                          className="text-blue-500 hover:underline"
+                          className="hover:text-mauve-12 hover:underline"
                           onClick={() => handleItemClick(prediction.typeId, prediction.itemName)}
                         >
                           {prediction.itemName}
@@ -267,12 +267,12 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                   ))
                 : sortedPredictions.map((prediction: Prediction) => (
                     <tr key={prediction.id} className="mx-2 text-mauve-11">
-                      <td className="border px-4 py-2">{prediction.locationName}</td>
-                      <td className="border px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
-                      <td className="border px-4 py-2">{prediction.horizon}</td>
-                      <td className="border px-4 py-2">{prediction.confidence}</td>
-                      <td className="border px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border px-4 py-2 sm:text-center lg:text-start">
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.locationName}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.horizon}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.confidence}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.datePredicted}</td>
+                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -182,19 +182,39 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
           <table className="w-full table-auto text-mauve-12 mx-4">
             <thead>
               <tr>
-                <th className="px-4 py-2" onClick={() => handleSort('locationName')}>
-                  <div className="flex items-center">Region {renderSortingIndicator('locationName')}</div>
+                <th className="px-4 py-2">
+                  <div className="flex items-center">
+                    <span onClick={() => handleSort('locationName')} className="hover:cursor-pointer">
+                      Region
+                    </span>
+                    {renderSortingIndicator('locationName')}
+                  </div>
                 </th>
-                <th className="px-4 py-2" onClick={() => handleSort('increase')}>
-                  <div className="flex items-center">Increase {renderSortingIndicator('increase')}</div>
+                <th className="px-4 py-2">
+                  <div className="flex items-center">
+                    <span onClick={() => handleSort('increase')} className="hover:cursor-pointer">
+                      Increase
+                    </span>
+                    {renderSortingIndicator('increase')}
+                  </div>
                 </th>
                 <th className="px-4 py-2">Horizon</th>
                 <th className="px-4 py-2">Confidence</th>
-                <th className="px-4 py-2" onClick={() => handleSort('datePredicted')}>
-                  <div className="flex items-center">Date Predicted {renderSortingIndicator('datePredicted')}</div>
+                <th className="px-4 py-2">
+                  <div className="flex items-center">
+                    <span onClick={() => handleSort('datePredicted')} className="hover:cursor-pointer">
+                      Date Predicted
+                    </span>
+                    {renderSortingIndicator('datePredicted')}
+                  </div>
                 </th>
-                <th className="px-4 py-2" onClick={() => handleSort('itemName')}>
-                  <div className="flex items-center">Item Name {renderSortingIndicator('itemName')}</div>
+                <th className="px-4 py-2">
+                  <div className="flex items-center">
+                    <span onClick={() => handleSort('itemName')} className="hover:cursor-pointer">
+                      Item Name
+                    </span>
+                    {renderSortingIndicator('itemName')}
+                  </div>
                 </th>
               </tr>
             </thead>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -168,10 +168,10 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
 
   return (
     <div className="h-full mx-12">
-      <div className="bg-violet-3 mt-16 text-mauve-11 rounded-lg overflow-hidden">
+      <div className="bg-violet-4 mt-16 rounded-lg overflow-hidden">
         <Graph currentItem={currentItem} currentItemName={currentItemName} currentRegionId={currentRegionId} />
       </div>
-      <div className="bg-violet-3 mt-16 rounded-lg">
+      <div className="bg-violet-4 mt-16 rounded-lg">
         <div className="flex justify-center pt-4">
           <div className="mx-4">
             <label htmlFor="regionSelect" className="text-mauve-12">

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -260,7 +260,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                       <td className="border border-violet-8 p-2">{prediction.horizon}</td>
                       <td className="border border-violet-8 p-2">{prediction.confidence}</td>
                       <td className="border border-violet-8 p-2">{prediction.datePredicted}</td>
-                      <td className="border border-violet-8 p-2 sm:text-center lg:text-start overflow-hidden">
+                      <td className="border border-violet-8 p-2 text-center overflow-hidden">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"
@@ -278,7 +278,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                       <td className="border border-violet-8 p-2">{prediction.horizon}</td>
                       <td className="border border-violet-8 p-2">{prediction.confidence}</td>
                       <td className="border border-violet-8 p-2">{prediction.datePredicted}</td>
-                      <td className="border border-violet-8 p-2 sm:text-center lg:text-start overflow-hidden">
+                      <td className="border border-violet-8 p-2 text-center overflow-hidden">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -49,6 +49,8 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   const [currentRegionId, setCurrentRegionId] = useState<number>(10000043);
   const [sortBy, setSortBy] = useState<string>('');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [filteredPredictions, setFilteredPredictions] = useState<Prediction[]>([]);
 
   const handleSort = (column: string) => {
     if (column === sortBy) {
@@ -151,6 +153,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     }
   });
 
+  const handleSearch = (searchQuery: string) => {
+    const filtered = predictionsWithItemNames.filter((prediction) =>
+      prediction.itemName.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+    setFilteredPredictions(filtered);
+  };
+
   return (
     <div className="h-full mx-12">
       <div className="bg-violet-3 mt-16 text-mauve-11 rounded-lg overflow-hidden">
@@ -175,7 +184,17 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
               <option value={10000042}>Metropolis</option>
             </select>
           </div>
-          <div className="mx-4 text-mauve-12">Search Item</div>
+          <div className="mx-4 text-mauve-12">
+            Search Item:
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                handleSearch(e.target.value);
+              }}
+            />
+          </div>
         </div>
         <div className="flex justify-center">
           {' '}
@@ -219,24 +238,43 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
               </tr>
             </thead>
             <tbody>
-              {sortedPredictions.map((prediction: Prediction) => (
-                <tr key={prediction.id} className="mx-2">
-                  <td className="border px-4 py-2">{prediction.locationName}</td>
-                  <td className="border px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
-                  <td className="border px-4 py-2">{prediction.horizon}</td>
-                  <td className="border px-4 py-2">{prediction.confidence}</td>
-                  <td className="border px-4 py-2">{prediction.datePredicted}</td>
-                  <td className="border px-4 py-2">
-                    {' '}
-                    <button
-                      className="text-blue-500 hover:underline"
-                      onClick={() => handleItemClick(prediction.typeId, prediction.itemName)}
-                    >
-                      {prediction.itemName}
-                    </button>
-                  </td>
-                </tr>
-              ))}
+              {searchTerm
+                ? filteredPredictions.map((prediction: Prediction) => (
+                    <tr key={prediction.id} className="mx-2">
+                      <td className="border px-4 py-2">{prediction.locationName}</td>
+                      <td className="border px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
+                      <td className="border px-4 py-2">{prediction.horizon}</td>
+                      <td className="border px-4 py-2">{prediction.confidence}</td>
+                      <td className="border px-4 py-2">{prediction.datePredicted}</td>
+                      <td className="border px-4 py-2">
+                        {' '}
+                        <button
+                          className="text-blue-500 hover:underline"
+                          onClick={() => handleItemClick(prediction.typeId, prediction.itemName)}
+                        >
+                          {prediction.itemName}
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                : sortedPredictions.map((prediction: Prediction) => (
+                    <tr key={prediction.id} className="mx-2">
+                      <td className="border px-4 py-2">{prediction.locationName}</td>
+                      <td className="border px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
+                      <td className="border px-4 py-2">{prediction.horizon}</td>
+                      <td className="border px-4 py-2">{prediction.confidence}</td>
+                      <td className="border px-4 py-2">{prediction.datePredicted}</td>
+                      <td className="border px-4 py-2">
+                        {' '}
+                        <button
+                          className="text-blue-500 hover:underline"
+                          onClick={() => handleItemClick(prediction.typeId, prediction.itemName)}
+                        >
+                          {prediction.itemName}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
             </tbody>
           </table>
         </div>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -251,16 +251,16 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                 </th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className='border border-violet-8'>
               {searchTerm
                 ? filteredPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className="mx-2 text-mauve-11 grid grid-cols-6">
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.locationName}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.horizon}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.confidence}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start overflow-hidden">
+                    <tr key={prediction.id} className=" text-mauve-11 grid grid-cols-6">
+                      <td className="border border-violet-8 p-2">{prediction.locationName}</td>
+                      <td className="border border-violet-8 p-2">{prediction.increase ? 'True' : 'False'}</td>
+                      <td className="border border-violet-8 p-2">{prediction.horizon}</td>
+                      <td className="border border-violet-8 p-2">{prediction.confidence}</td>
+                      <td className="border border-violet-8 p-2">{prediction.datePredicted}</td>
+                      <td className="border border-violet-8 p-2 sm:text-center lg:text-start overflow-hidden">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"
@@ -272,13 +272,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                     </tr>
                   ))
                 : sortedPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className="mx-2 text-mauve-11 grid grid-cols-6">
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.locationName}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.horizon}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.confidence}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start overflow-hidden">
+                    <tr key={prediction.id} className=" text-mauve-11 grid grid-cols-6">
+                      <td className="border border-violet-8 p-2">{prediction.locationName}</td>
+                      <td className="border border-violet-8 p-2">{prediction.increase ? 'True' : 'False'}</td>
+                      <td className="border border-violet-8 p-2">{prediction.horizon}</td>
+                      <td className="border border-violet-8 p-2">{prediction.confidence}</td>
+                      <td className="border border-violet-8 p-2">{prediction.datePredicted}</td>
+                      <td className="border border-violet-8 p-2 sm:text-center lg:text-start overflow-hidden">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -161,7 +161,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
 
   const handleSearch = (searchQuery: string) => {
     const filtered = predictionsWithItemNames.filter((prediction: Prediction) =>
-      prediction.itemName.toLowerCase().includes(searchQuery.toLowerCase()),
+      prediction.itemName?.toLowerCase().includes(searchQuery.toLowerCase()),
     );
     setFilteredPredictions(filtered);
   };

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -181,7 +181,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
               id="regionSelect"
               value={currentRegionId}
               onChange={(event) => changeRegion(event)}
-              className="bg-violet-9 hover:bg-violet-10 ml-2 rounded-lg"
+              className="bg-violet-5 hover:bg-violet-6 ml-2 rounded-lg border-violet-8 border-2"
             >
               <option value={10000043}>Domain</option>
               <option value={10000002}>The Forge</option>
@@ -193,7 +193,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
           <div className="mx-4 text-mauve-12">
             <label htmlFor="searchItem">Search Item:</label>
             <input
-              className="bg-violet-9 hover:bg-violet-10 rounded-lg ml-2 text-mauve-12"
+              className="bg-violet-5 hover:bg-violet-6 rounded-lg ml-2 text-mauve-12 border-violet-8 border-2"
               type="text"
               id="searchItem"
               value={searchTerm}

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -153,11 +153,11 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     }
   });
 
-  const changeRegion = (event: React.ChangeEvent<HTMLSelectElement>) =>{
-    setSortBy('')
-    setSortOrder('asc')
-    setCurrentRegionId(parseInt(event.target.value))
-  }
+  const changeRegion = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSortBy('');
+    setSortOrder('asc');
+    setCurrentRegionId(parseInt(event.target.value));
+  };
 
   const handleSearch = (searchQuery: string) => {
     const filtered = predictionsWithItemNames.filter((prediction: Prediction) =>
@@ -191,9 +191,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             </select>
           </div>
           <div className="mx-4 text-mauve-12">
-            <label htmlFor="searchItem">
-              Search Item:
-            </label>
+            <label htmlFor="searchItem">Search Item:</label>
             <input
               className="bg-violet-7 rounded-lg ml-2 text-mauve-12"
               type="text"
@@ -256,7 +254,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                       <td className="border px-4 py-2">{prediction.horizon}</td>
                       <td className="border px-4 py-2">{prediction.confidence}</td>
                       <td className="border px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border px-4 py-2">
+                      <td className="border px-4 py-2 sm:text-center lg:text-start">
                         {' '}
                         <button
                           className="text-blue-500 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -51,6 +51,8 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [filteredPredictions, setFilteredPredictions] = useState<Prediction[]>([]);
+  const itemsPerPage = 50;
+  const [currentPage, setCurrentPage] = useState<number>(1);
 
   const handleSort = (column: string) => {
     if (column === sortBy) {
@@ -135,7 +137,8 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     locationName: locationMap[node.regionId],
   }));
 
-  const sortedPredictions = [...predictionsWithItemNames].sort((a, b) => {
+
+  let sortedPredictions = [...predictionsWithItemNames].sort((a, b) => {
     if (sortBy === 'locationName') {
       return sortOrder === 'asc'
         ? a.locationName.localeCompare(b.locationName)
@@ -153,6 +156,8 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     }
   });
 
+  sortedPredictions = sortedPredictions.slice(itemsPerPage * currentPage - 1, currentPage * itemsPerPage + itemsPerPage)
+
   const changeRegion = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setSortBy('');
     setSortOrder('asc');
@@ -163,7 +168,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     const filtered = predictionsWithItemNames.filter((prediction: Prediction) =>
       prediction.itemName?.toLowerCase().includes(searchQuery.toLowerCase()),
     );
-    setFilteredPredictions(filtered);
+    setFilteredPredictions(filtered.slice(0,10));
   };
 
   return (
@@ -203,6 +208,14 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
               }}
             />
           </div>
+        </div>
+        <div className='flex w-full justify-center'>
+          <button className='px-2' onClick={() => setCurrentPage(currentPage - 1)}>
+            Previous
+          </button>
+          <button className='px-2' onClick={() => setCurrentPage(currentPage + 1)}>
+            Next
+          </button>
         </div>
         <div className="flex justify-center">
           {' '}

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -210,14 +210,14 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             />
           </div>
         </div>
-        <div className='flex w-full justify-center'>
-          <button className='px-2' onClick={() => setCurrentPage(currentPage - 1)}>
+        <div className='flex w-full justify-center my-2'>
+          <button className='px-2 disabled:text-mauve-10' onClick={() => setCurrentPage(currentPage - 1)} disabled={currentPage == 1}>
             Previous
           </button>
           <div>
-            Page: {currentPage} of {totalPages}
+            {currentPage} of {totalPages}
           </div>
-          <button className='px-2' onClick={() => setCurrentPage(currentPage + 1)}>
+          <button className='px-2 disabled:text-mauve-10' onClick={() => setCurrentPage(currentPage + 1)} disabled={currentPage == totalPages}>
             Next
           </button>
         </div>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -2,7 +2,7 @@ import Graph from './graph';
 import { useState, useEffect } from 'react';
 import { ALL_PREDICTIONS_QUERY } from '@/apollo/graphql-queries';
 const { useQuery } = require('@apollo/client');
-import { ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
+import { ArrowUpIcon, ArrowDownIcon, CaretSortIcon } from '@radix-ui/react-icons';
 
 interface LocationNode {
   regionId: string;
@@ -62,8 +62,9 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   const renderSortingIndicator = (column: string) => {
     if (column === sortBy) {
       return sortOrder === 'asc' ? <ArrowUpIcon /> : <ArrowDownIcon />;
+    } else {
+      return <CaretSortIcon />;
     }
-    return null;
   };
 
   const [currentItemName, setCurrentItemName] = useState<string | undefined>();

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -137,7 +137,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     locationName: locationMap[node.regionId],
   }));
 
-  const totalPages = Math.floor(predictionsWithItemNames.length / itemsPerPage)
+  const totalPages = Math.floor(predictionsWithItemNames.length / itemsPerPage);
 
   let sortedPredictions = [...predictionsWithItemNames].sort((a, b) => {
     if (sortBy === 'locationName') {
@@ -157,7 +157,10 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     }
   });
 
-  sortedPredictions = sortedPredictions.slice(itemsPerPage * currentPage - 1, currentPage * itemsPerPage + itemsPerPage)
+  sortedPredictions = sortedPredictions.slice(
+    itemsPerPage * currentPage - 1,
+    currentPage * itemsPerPage + itemsPerPage,
+  );
 
   const changeRegion = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setSortBy('');
@@ -166,10 +169,10 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   };
 
   const handleSearch = (searchQuery: string) => {
-    const filtered = predictionsWithItemNames.filter((prediction: Prediction) =>
-      prediction.itemName?.toLowerCase().includes(searchQuery.toLowerCase()),
+    const filtered = predictionsWithItemNames.filter(
+      (prediction: Prediction) => prediction.itemName?.toLowerCase().includes(searchQuery.toLowerCase()),
     );
-    setFilteredPredictions(filtered.slice(0,10));
+    setFilteredPredictions(filtered.slice(0, 10));
   };
 
   return (
@@ -210,14 +213,22 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             />
           </div>
         </div>
-        <div className='flex w-full justify-center my-2'>
-          <button className='px-2 disabled:text-mauve-10' onClick={() => setCurrentPage(currentPage - 1)} disabled={currentPage == 1}>
+        <div className="flex w-full justify-center my-2">
+          <button
+            className="px-2 disabled:text-mauve-10"
+            onClick={() => setCurrentPage(currentPage - 1)}
+            disabled={currentPage == 1}
+          >
             Previous
           </button>
           <div>
             {currentPage} of {totalPages}
           </div>
-          <button className='px-2 disabled:text-mauve-10' onClick={() => setCurrentPage(currentPage + 1)} disabled={currentPage == totalPages}>
+          <button
+            className="px-2 disabled:text-mauve-10"
+            onClick={() => setCurrentPage(currentPage + 1)}
+            disabled={currentPage == totalPages}
+          >
             Next
           </button>
         </div>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -59,6 +59,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     }
   };
 
+  const renderSortingIndicator = (column: string) => {
+    if (column === sortBy) {
+      return sortOrder === 'asc' ? <ArrowUpIcon /> : <ArrowDownIcon />;
+    }
+    return null;
+  };
+
   const [currentItemName, setCurrentItemName] = useState<string | undefined>();
 
   const handleItemClick = (itemId: number, itemName: string) => {
@@ -175,30 +182,18 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             <thead>
               <tr>
                 <th className="px-4 py-2" onClick={() => handleSort('locationName')}>
-                  <div className="flex items-center">
-                    Region {sortBy === 'locationName' && sortOrder === 'asc' && <ArrowUpIcon />}
-                    {sortBy === 'locationName' && sortOrder === 'desc' && <ArrowDownIcon />}
-                  </div>
+                  <div className="flex items-center">Region {renderSortingIndicator('locationName')}</div>
                 </th>
                 <th className="px-4 py-2" onClick={() => handleSort('increase')}>
-                  <div className="flex items-center">
-                    Increase {sortBy === 'increase' && sortOrder === 'asc' && <ArrowUpIcon />}
-                    {sortBy === 'increase' && sortOrder === 'desc' && <ArrowDownIcon />}
-                  </div>
+                  <div className="flex items-center">Increase {renderSortingIndicator('increase')}</div>
                 </th>
                 <th className="px-4 py-2">Horizon</th>
                 <th className="px-4 py-2">Confidence</th>
                 <th className="px-4 py-2" onClick={() => handleSort('datePredicted')}>
-                  <div className="flex items-center">
-                    Date Predicted {sortBy === 'datePredicted' && sortOrder === 'asc' && <ArrowUpIcon />}
-                    {sortBy === 'datePredicted' && sortOrder === 'desc' && <ArrowDownIcon />}
-                  </div>
+                  <div className="flex items-center">Date Predicted {renderSortingIndicator('datePredicted')}</div>
                 </th>
                 <th className="px-4 py-2" onClick={() => handleSort('itemName')}>
-                  <div className="flex items-center">
-                    Item Name {sortBy === 'itemName' && sortOrder === 'asc' && <ArrowUpIcon />}
-                    {sortBy === 'itemName' && sortOrder === 'desc' && <ArrowDownIcon />}
-                  </div>
+                  <div className="flex items-center">Item Name {renderSortingIndicator('itemName')}</div>
                 </th>
               </tr>
             </thead>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -189,6 +189,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
               Search Item:
             </label>
             <input
+              className="bg-violet-7 rounded-lg ml-2 text-mauve-12"
               type="text"
               id="searchItem"
               value={searchTerm}

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -2,6 +2,7 @@ import Graph from './graph';
 import { useState, useEffect } from 'react';
 import { ALL_PREDICTIONS_QUERY } from '@/apollo/graphql-queries';
 const { useQuery } = require('@apollo/client');
+import { ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
 
 interface LocationNode {
   regionId: string;
@@ -173,19 +174,31 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
           <table className="w-full table-auto text-mauve-12 mx-4">
             <thead>
               <tr>
-                <th className="px-4 py-2">Region</th>
+                <th className="px-4 py-2" onClick={() => handleSort('locationName')}>
+                  <div className="flex items-center">
+                    Region {sortBy === 'locationName' && sortOrder === 'asc' && <ArrowUpIcon />}
+                    {sortBy === 'locationName' && sortOrder === 'desc' && <ArrowDownIcon />}
+                  </div>
+                </th>
                 <th className="px-4 py-2" onClick={() => handleSort('increase')}>
-                  Increase
+                  <div className="flex items-center">
+                    Increase {sortBy === 'increase' && sortOrder === 'asc' && <ArrowUpIcon />}
+                    {sortBy === 'increase' && sortOrder === 'desc' && <ArrowDownIcon />}
+                  </div>
                 </th>
-                <th className="px-4 py-2" onClick={() => handleSort('horizon')}>
-                  Horizon
-                </th>
+                <th className="px-4 py-2">Horizon</th>
                 <th className="px-4 py-2">Confidence</th>
                 <th className="px-4 py-2" onClick={() => handleSort('datePredicted')}>
-                  Date predicted
+                  <div className="flex items-center">
+                    Date Predicted {sortBy === 'datePredicted' && sortOrder === 'asc' && <ArrowUpIcon />}
+                    {sortBy === 'datePredicted' && sortOrder === 'desc' && <ArrowDownIcon />}
+                  </div>
                 </th>
                 <th className="px-4 py-2" onClick={() => handleSort('itemName')}>
-                  Item name
+                  <div className="flex items-center">
+                    Item Name {sortBy === 'itemName' && sortOrder === 'asc' && <ArrowUpIcon />}
+                    {sortBy === 'itemName' && sortOrder === 'desc' && <ArrowDownIcon />}
+                  </div>
                 </th>
               </tr>
             </thead>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -240,7 +240,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
         </div>
         <div className="flex justify-center">
           {' '}
-          <table className="w-full table-auto text-mauve-11 mx-4">
+          <table className="w-full table-auto text-mauve-11 mx-4 mb-4">
             <thead>
               <tr className="grid grid-flow-col auto-cols-max grid-cols-9">
                 <th className="px-4 py-2">

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -268,7 +268,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                       <td className="border px-4 py-2">{prediction.horizon}</td>
                       <td className="border px-4 py-2">{prediction.confidence}</td>
                       <td className="border px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border px-4 py-2">
+                      <td className="border px-4 py-2 sm:text-center lg:text-start">
                         {' '}
                         <button
                           className="text-blue-500 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -2,7 +2,7 @@ import Graph from './graph';
 import { useState, useEffect } from 'react';
 import { ALL_PREDICTIONS_QUERY } from '@/apollo/graphql-queries';
 const { useQuery } = require('@apollo/client');
-import { ArrowUpIcon, ArrowDownIcon, CaretSortIcon } from '@radix-ui/react-icons';
+import { ArrowUpIcon, ArrowDownIcon, CaretSortIcon, ArrowLeftIcon, ArrowRightIcon } from '@radix-ui/react-icons';
 
 interface LocationNode {
   regionId: string;
@@ -219,21 +219,23 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
         </div>
         <div className="flex w-full justify-center my-2">
           <button
-            className="px-2 disabled:text-mauve-10"
+            className="px-2 disabled:text-mauve-10 flex flex-row items-center"
             onClick={() => setCurrentPage(currentPage - 1)}
             disabled={currentPage == 1}
           >
-            Previous
+            <ArrowLeftIcon />
+            <span className="mx-1">Previous</span>
           </button>
           <div>
             {currentPage} of {totalPages}
           </div>
           <button
-            className="px-2 disabled:text-mauve-10"
+            className="px-2 disabled:text-mauve-10 flex flex-row items-center"
             onClick={() => setCurrentPage(currentPage + 1)}
             disabled={currentPage == totalPages}
           >
-            Next
+            <span className="mx-1">Next</span>
+            <ArrowRightIcon />
           </button>
         </div>
         <div className="flex justify-center">

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -208,7 +208,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
           {' '}
           <table className="w-full table-auto text-mauve-11 mx-4">
             <thead>
-              <tr className="grid grid-cols-6">
+              <tr className="grid grid-flow-col auto-cols-max grid-cols-9">
                 <th className="px-4 py-2">
                   <div className="flex items-center">
                     <span
@@ -241,7 +241,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                     {renderSortingIndicator('datePredicted')}
                   </div>
                 </th>
-                <th className="px-4 py-2">
+                <th className="px-4 py-2 col-span-4">
                   <div className="flex items-center">
                     <span onClick={() => handleSort('itemName')} className="hover:cursor-pointer hover:text-mauve-12">
                       Item Name
@@ -251,7 +251,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                 </th>
               </tr>
             </thead>
-            <tbody className='border border-violet-8'>
+            <tbody className="border border-violet-8">
               {searchTerm
                 ? filteredPredictions.map((prediction: Prediction) => (
                     <tr key={prediction.id} className=" text-mauve-11 grid grid-cols-6">
@@ -272,13 +272,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                     </tr>
                   ))
                 : sortedPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className=" text-mauve-11 grid grid-cols-6">
+                    <tr key={prediction.id} className=" text-mauve-11 grid grid-flow-col auto-cols-max grid-cols-9">
                       <td className="border border-violet-8 p-2">{prediction.locationName}</td>
                       <td className="border border-violet-8 p-2">{prediction.increase ? 'True' : 'False'}</td>
                       <td className="border border-violet-8 p-2">{prediction.horizon}</td>
                       <td className="border border-violet-8 p-2">{prediction.confidence}</td>
                       <td className="border border-violet-8 p-2">{prediction.datePredicted}</td>
-                      <td className="border border-violet-8 p-2 text-center overflow-hidden">
+                      <td className="border border-violet-8 p-2 text-center overflow-hidden col-span-4">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -208,10 +208,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
           {' '}
           <table className="w-full table-auto text-mauve-11 mx-4">
             <thead>
-              <tr>
+              <tr className="grid grid-cols-6">
                 <th className="px-4 py-2">
                   <div className="flex items-center">
-                    <span onClick={() => handleSort('locationName')} className="hover:cursor-pointer hover:text-mauve-12">
+                    <span
+                      onClick={() => handleSort('locationName')}
+                      className="hover:cursor-pointer hover:text-mauve-12"
+                    >
                       Region
                     </span>
                     {renderSortingIndicator('locationName')}
@@ -229,7 +232,10 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                 <th className="px-4 py-2">Confidence</th>
                 <th className="px-4 py-2">
                   <div className="flex items-center">
-                    <span onClick={() => handleSort('datePredicted')} className="hover:cursor-pointer hover:text-mauve-12">
+                    <span
+                      onClick={() => handleSort('datePredicted')}
+                      className="hover:cursor-pointer hover:text-mauve-12"
+                    >
                       Date Predicted
                     </span>
                     {renderSortingIndicator('datePredicted')}
@@ -248,13 +254,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             <tbody>
               {searchTerm
                 ? filteredPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className="mx-2 text-mauve-11">
+                    <tr key={prediction.id} className="mx-2 text-mauve-11 grid grid-cols-6">
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.locationName}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.horizon}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.confidence}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start">
+                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start overflow-hidden">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"
@@ -266,13 +272,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                     </tr>
                   ))
                 : sortedPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className="mx-2 text-mauve-11">
+                    <tr key={prediction.id} className="mx-2 text-mauve-11 grid grid-cols-6">
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.locationName}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.horizon}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.confidence}</td>
                       <td className="border-2 border-violet-8 px-4 py-2">{prediction.datePredicted}</td>
-                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start">
+                      <td className="border-2 border-violet-8 px-4 py-2 sm:text-center lg:text-start overflow-hidden">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -254,13 +254,13 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             <tbody className="border border-violet-8">
               {searchTerm
                 ? filteredPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className=" text-mauve-11 grid grid-cols-6">
+                    <tr key={prediction.id} className="text-mauve-11 grid grid-flow-col auto-cols-max grid-cols-9">
                       <td className="border border-violet-8 p-2">{prediction.locationName}</td>
                       <td className="border border-violet-8 p-2">{prediction.increase ? 'True' : 'False'}</td>
                       <td className="border border-violet-8 p-2">{prediction.horizon}</td>
                       <td className="border border-violet-8 p-2">{prediction.confidence}</td>
                       <td className="border border-violet-8 p-2">{prediction.datePredicted}</td>
-                      <td className="border border-violet-8 p-2 text-center overflow-hidden">
+                      <td className="border border-violet-8 p-2 text-center overflow-hidden col-span-4">
                         {' '}
                         <button
                           className="hover:text-mauve-12 hover:underline"

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -181,7 +181,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
               id="regionSelect"
               value={currentRegionId}
               onChange={(event) => changeRegion(event)}
-              className="bg-violet-7 ml-2 rounded-lg"
+              className="bg-violet-9 hover:bg-violet-10 ml-2 rounded-lg"
             >
               <option value={10000043}>Domain</option>
               <option value={10000002}>The Forge</option>
@@ -193,7 +193,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
           <div className="mx-4 text-mauve-12">
             <label htmlFor="searchItem">Search Item:</label>
             <input
-              className="bg-violet-7 rounded-lg ml-2 text-mauve-12"
+              className="bg-violet-9 hover:bg-violet-10 rounded-lg ml-2 text-mauve-12"
               type="text"
               id="searchItem"
               value={searchTerm}
@@ -206,12 +206,12 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
         </div>
         <div className="flex justify-center">
           {' '}
-          <table className="w-full table-auto text-mauve-12 mx-4">
+          <table className="w-full table-auto text-mauve-11 mx-4">
             <thead>
               <tr>
                 <th className="px-4 py-2">
                   <div className="flex items-center">
-                    <span onClick={() => handleSort('locationName')} className="hover:cursor-pointer">
+                    <span onClick={() => handleSort('locationName')} className="hover:cursor-pointer hover:text-mauve-12">
                       Region
                     </span>
                     {renderSortingIndicator('locationName')}
@@ -219,7 +219,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                 </th>
                 <th className="px-4 py-2">
                   <div className="flex items-center">
-                    <span onClick={() => handleSort('increase')} className="hover:cursor-pointer">
+                    <span onClick={() => handleSort('increase')} className="hover:cursor-pointer hover:text-mauve-12">
                       Increase
                     </span>
                     {renderSortingIndicator('increase')}
@@ -229,7 +229,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                 <th className="px-4 py-2">Confidence</th>
                 <th className="px-4 py-2">
                   <div className="flex items-center">
-                    <span onClick={() => handleSort('datePredicted')} className="hover:cursor-pointer">
+                    <span onClick={() => handleSort('datePredicted')} className="hover:cursor-pointer hover:text-mauve-12">
                       Date Predicted
                     </span>
                     {renderSortingIndicator('datePredicted')}
@@ -237,7 +237,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                 </th>
                 <th className="px-4 py-2">
                   <div className="flex items-center">
-                    <span onClick={() => handleSort('itemName')} className="hover:cursor-pointer">
+                    <span onClick={() => handleSort('itemName')} className="hover:cursor-pointer hover:text-mauve-12">
                       Item Name
                     </span>
                     {renderSortingIndicator('itemName')}
@@ -266,7 +266,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                     </tr>
                   ))
                 : sortedPredictions.map((prediction: Prediction) => (
-                    <tr key={prediction.id} className="mx-2">
+                    <tr key={prediction.id} className="mx-2 text-mauve-11">
                       <td className="border px-4 py-2">{prediction.locationName}</td>
                       <td className="border px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>
                       <td className="border px-4 py-2">{prediction.horizon}</td>
@@ -275,7 +275,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
                       <td className="border px-4 py-2 sm:text-center lg:text-start">
                         {' '}
                         <button
-                          className="text-blue-500 hover:underline"
+                          className="hover:text-mauve-12 hover:underline"
                           onClick={() => handleItemClick(prediction.typeId, prediction.itemName)}
                         >
                           {prediction.itemName}

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -129,7 +129,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     return <div>No predictions available for this region.</div>;
   }
 
-  const predictionsWithItemNames = newPredictions.map(({ node }) => ({
+  const predictionsWithItemNames = newPredictions.map(({ node }: { node: Prediction }) => ({
     ...node,
     itemName: itemMap[node.typeId],
     locationName: locationMap[node.regionId],
@@ -153,10 +153,10 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     }
   });
 
-  const changeRegion = (e) =>{
+  const changeRegion = (event: React.ChangeEvent<HTMLSelectElement>) =>{
     setSortBy('')
     setSortOrder('asc')
-    setCurrentRegionId(parseInt(e.target.value))
+    setCurrentRegionId(parseInt(event.target.value))
   }
 
   const handleSearch = (searchQuery: string) => {
@@ -180,7 +180,7 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             <select
               id="regionSelect"
               value={currentRegionId}
-              onChange={(e) => changeRegion(e)}
+              onChange={(event) => changeRegion(event)}
               className="bg-violet-7 ml-2 rounded-lg"
             >
               <option value={10000043}>Domain</option>

--- a/packages/celestia-app/src/components/hero.tsx
+++ b/packages/celestia-app/src/components/hero.tsx
@@ -46,6 +46,17 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
   const [currentItem, setCurrentItem] = useState<number | undefined>();
   const [isLoading, setIsLoading] = useState(true);
   const [currentRegionId, setCurrentRegionId] = useState<number>(10000043);
+  const [sortBy, setSortBy] = useState<string>('');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+
+  const handleSort = (column: string) => {
+    if (column === sortBy) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(column);
+      setSortOrder('asc');
+    }
+  };
 
   const [currentItemName, setCurrentItemName] = useState<string | undefined>();
 
@@ -113,6 +124,24 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
     locationName: locationMap[node.regionId],
   }));
 
+  const sortedPredictions = [...predictionsWithItemNames].sort((a, b) => {
+    if (sortBy === 'locationName') {
+      return sortOrder === 'asc'
+        ? a.locationName.localeCompare(b.locationName)
+        : b.locationName.localeCompare(a.locationName);
+    } else if (sortBy === 'increase') {
+      return sortOrder === 'asc' ? a.increase - b.increase : b.increase - a.increase;
+    } else if (sortBy === 'itemName') {
+      return sortOrder === 'asc' ? a.itemName.localeCompare(b.itemName) : b.itemName.localeCompare(a.itemName);
+    } else if (sortBy === 'datePredicted') {
+      return sortOrder === 'asc'
+        ? a.datePredicted.localeCompare(b.datePredicted)
+        : b.datePredicted.localeCompare(a.datePredicted);
+    } else {
+      return 0;
+    }
+  });
+
   return (
     <div className="h-full mx-12">
       <div className="bg-violet-3 mt-16 text-mauve-11 rounded-lg overflow-hidden">
@@ -145,15 +174,23 @@ const Hero = ({ itemNames, locationNames }: HeroProps) => {
             <thead>
               <tr>
                 <th className="px-4 py-2">Region</th>
-                <th className="px-4 py-2">Increase</th>
-                <th className="px-4 py-2">Horizon</th>
+                <th className="px-4 py-2" onClick={() => handleSort('increase')}>
+                  Increase
+                </th>
+                <th className="px-4 py-2" onClick={() => handleSort('horizon')}>
+                  Horizon
+                </th>
                 <th className="px-4 py-2">Confidence</th>
-                <th className="px-4 py-2">Date predicted</th>
-                <th className="px-4 py-2">Item name</th>
+                <th className="px-4 py-2" onClick={() => handleSort('datePredicted')}>
+                  Date predicted
+                </th>
+                <th className="px-4 py-2" onClick={() => handleSort('itemName')}>
+                  Item name
+                </th>
               </tr>
             </thead>
             <tbody>
-              {predictionsWithItemNames.map((prediction: Prediction) => (
+              {sortedPredictions.map((prediction: Prediction) => (
                 <tr key={prediction.id} className="mx-2">
                   <td className="border px-4 py-2">{prediction.locationName}</td>
                   <td className="border px-4 py-2">{prediction.increase ? 'True' : 'False'}</td>

--- a/packages/celestia-app/src/pages/index.tsx
+++ b/packages/celestia-app/src/pages/index.tsx
@@ -52,7 +52,7 @@ interface HomeProps {
 
 const Home = ({ itemNames, locationNames }: HomeProps) => {
   return (
-    <div className="w-full">
+    <div className="w-full bg-gradient">
       <Header />
       <Hero itemNames={itemNames} locationNames={locationNames} />
       <Footer />

--- a/packages/celestia-app/src/pages/index.tsx
+++ b/packages/celestia-app/src/pages/index.tsx
@@ -52,7 +52,7 @@ interface HomeProps {
 
 const Home = ({ itemNames, locationNames }: HomeProps) => {
   return (
-    <div className="w-full bg-gradient">
+    <div className="w-full bg-gradient hover:cursor-default">
       <Header />
       <Hero itemNames={itemNames} locationNames={locationNames} />
       <Footer />

--- a/packages/celestia-app/tailwind.config.ts
+++ b/packages/celestia-app/tailwind.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
-        'gradient': 'linear-gradient(to bottom, #17151f, #1c172b)',
+        gradient: 'linear-gradient(to bottom, #17151f, #1c172b)',
       },
       colors: {
         'mauve-1': mauveDark.mauve1,

--- a/packages/celestia-app/tailwind.config.ts
+++ b/packages/celestia-app/tailwind.config.ts
@@ -12,6 +12,7 @@ const config: Config = {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+        'gradient': 'linear-gradient(to bottom, #17151f, #1c172b)',
       },
       colors: {
         'mauve-1': mauveDark.mauve1,


### PR DESCRIPTION
Did quite a few things in this one:
- Updated the grid layout for the table of item predictions
- Lots of color changes
- Added a search feature
- Added ability to sort by region, confidence, item name, increase, date predicted
- Pages for the predictions that way you don't have to scroll through 400 items

What it looks like now.
![Screenshot 2023-10-02 at 9 07 58 AM](https://github.com/Codykilpatrick/Celestia/assets/92489375/bfb1949c-e120-4361-9567-25fc68faa96c)

Closes #49 
